### PR TITLE
[PR-48] Splash 화면 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,23 +20,12 @@
             android:launchMode="singleTop"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".presentation.myteam.create.TeamCreateActivity"
             android:launchMode="singleTop"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity"/>
-
-        <activity
-            android:name=".presentation.onboarding.OnboardingActivity"
-            android:launchMode="singleTop"
-            android:screenOrientation="portrait"
-            tools:ignore="LockedOrientationActivity" />
         <activity
             android:name=".presentation.teammain.TeamMainActivity"
             android:launchMode="singleTop"
@@ -67,6 +56,17 @@
             android:launchMode="singleTop"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity" />
+        <activity
+            android:name=".presentation.splash.SplashActivity"
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientationActivity" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/kr/yapp/teamplay/presentation/signin/SigninActivity.kt
+++ b/app/src/main/java/kr/yapp/teamplay/presentation/signin/SigninActivity.kt
@@ -1,5 +1,6 @@
 package kr.yapp.teamplay.presentation.signin
 
+import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
@@ -16,8 +17,19 @@ import kotlinx.android.synthetic.main.fragment_signin_password.*
 import kr.yapp.teamplay.R
 import kr.yapp.teamplay.databinding.ActivitySigninBinding
 import kr.yapp.teamplay.presentation.myteam.MyTeamSelectActivity
+import org.jetbrains.anko.intentFor
+import org.jetbrains.anko.singleTop
+import org.jetbrains.anko.startActivity
 
 class SigninActivity : AppCompatActivity() {
+
+    companion object {
+        fun start(context : Context) {
+            context.startActivity(
+                context.intentFor<SigninActivity>().singleTop()
+            )
+        }
+    }
 
     private val signinViewModel: SigninViewModel by lazy {
         ViewModelProvider(this).get(SigninViewModel::class.java)

--- a/app/src/main/java/kr/yapp/teamplay/presentation/signin/SigninEmailFragment.kt
+++ b/app/src/main/java/kr/yapp/teamplay/presentation/signin/SigninEmailFragment.kt
@@ -45,7 +45,7 @@ class SigninEmailFragment(signinViewModel: SigninViewModel) : Fragment() {
     private fun setLiveDataObserver() {
         signinViewModel.signInEmailClick.observe(viewLifecycleOwner, Observer {
             signinViewModel.setSigninEmail(et_signin_email.text.toString())
-            signinViewModel.checkAlreadyUser()
+            signinViewModel.checkRegisteredUser()
         })
 
         signinViewModel.signInEmailError.observe(viewLifecycleOwner, Observer {

--- a/app/src/main/java/kr/yapp/teamplay/presentation/signin/SigninPasswordFragment.kt
+++ b/app/src/main/java/kr/yapp/teamplay/presentation/signin/SigninPasswordFragment.kt
@@ -44,7 +44,7 @@ class SigninPasswordFragment(signinViewModel: SigninViewModel) : Fragment() {
 
     private fun setLiveDataObserver() {
         signinViewModel.signInPasswordClick.observe(viewLifecycleOwner, Observer {
-            signinViewModel.checkEmailPassword()
+            signinViewModel.submitEmailPassword()
         })
 
         signinViewModel.signInPasswordError.observe(viewLifecycleOwner, Observer {

--- a/app/src/main/java/kr/yapp/teamplay/presentation/signin/SigninViewModel.kt
+++ b/app/src/main/java/kr/yapp/teamplay/presentation/signin/SigninViewModel.kt
@@ -12,8 +12,6 @@ import kr.yapp.teamplay.domain.usecase.EmailCheckUsecase
 import kr.yapp.teamplay.domain.usecase.SigninUsecase
 import kr.yapp.teamplay.presentation.util.SingleLiveEvent
 import kr.yapp.teamplay.presentation.util.sha256
-import okhttp3.ResponseBody
-import retrofit2.HttpException
 
 class SigninViewModel(
     private val signinUsecase: SigninUsecase =
@@ -45,7 +43,7 @@ class SigninViewModel(
     }
 
     // check that an email is registered or not
-    fun checkAlreadyUser(){
+    fun checkRegisteredUser(){
         val emailRegExp = "^[a-zA-Z0-9._%^-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$".toRegex()
         val matchResult = emailRegExp.matches(signinEmail.value.toString())
 
@@ -68,7 +66,7 @@ class SigninViewModel(
         }
     }
 
-    fun checkEmailPassword() {
+    fun submitEmailPassword() {
         val passwordRegExp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[0-9]).{8,20}$".toRegex()
         val matchResult = passwordRegExp.matches(signinPassword.value.toString())
 
@@ -80,8 +78,7 @@ class SigninViewModel(
                 .subscribe({
                     signInSuccess.call()
                 }, {
-                    val body: ResponseBody? = (it as HttpException).response()?.errorBody()
-                    Log.d("MyTag", it.localizedMessage!!)
+                    signInPasswordError.call()
                 })
                 .addTo(compositeDisposable)
         } else {

--- a/app/src/main/java/kr/yapp/teamplay/presentation/splash/SplashActivity.kt
+++ b/app/src/main/java/kr/yapp/teamplay/presentation/splash/SplashActivity.kt
@@ -1,0 +1,37 @@
+package kr.yapp.teamplay.presentation.splash
+
+import android.os.Bundle
+import android.view.animation.Animation
+import android.view.animation.AnimationUtils
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import kotlinx.android.synthetic.main.activity_splash.*
+import kr.yapp.teamplay.R
+import kr.yapp.teamplay.databinding.ActivitySplashBinding
+import kr.yapp.teamplay.presentation.signin.SigninActivity
+
+class SplashActivity : AppCompatActivity() {
+    private lateinit var binding: ActivitySplashBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_splash)
+        startSplashAnimation()
+    }
+
+    private fun startSplashAnimation() {
+        val logoAnimation = AnimationUtils.loadAnimation(this, R.anim.logo_fade_in)
+        splash_logo.startAnimation(logoAnimation)
+
+        logoAnimation.setAnimationListener(object : Animation.AnimationListener {
+            override fun onAnimationRepeat(animation: Animation?) {}
+            override fun onAnimationStart(animation: Animation?) {}
+            override fun onAnimationEnd(animation: Animation?) {
+                SigninActivity.start(this@SplashActivity)
+                finish()
+            }
+
+        })
+    }
+}

--- a/app/src/main/res/anim/logo_fade_in.xml
+++ b/app/src/main/res/anim/logo_fade_in.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:anim/accelerate_decelerate_interpolator"
+    android:shareInterpolator="true">
+    <alpha
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0"
+        android:duration="3000" />
+</set>

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/bg">
+
+    <ImageView
+        android:id="@+id/splash_logo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:scaleX="1.5"
+        android:scaleY="1.5"
+        android:src="@drawable/logotype"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,9 +24,9 @@
     <string name="signup_nickname">이제 멋진 닉네임만 정하면 끝이에요!</string>
     <string name="next">다음</string>
     <string name="signin_error_email">올바른 이메일을 입력해주세요.</string>
-    <string name="signin_error_password">올바른 패스워드를 입력해주세요.</string>
+    <string name="signin_error_password">비밀번호가 일치하지 않습니다.</string>
     <string name="signup_error_email">올바른 이메일을 입력해주세요.</string>
-    <string name="signup_error_password">올바른 패스워드를 입력해주세요.</string>
+    <string name="signup_error_password">올바른 비밀번호를 입력해주세요.</string>
     <string name="signup_error_nickname">올바른 닉네임을 입력해주세요.</string>
 
     <string name="myTeamUserNameHint">안녕하세요,</string>


### PR DESCRIPTION
# FEATURE Pull Request

## Description

PR에 대한 간단한 설명:
- Splash 화면 추가입니다. 온보딩 엑티비티는 비활성화(추후 기능확장 고려해서 코드는 남겨놨습니다), 앱 실행시 메인은 Splash로 이동합니다. Splash 종료시, Signin Activity로 이동합니다.
로그인과 회원가입에서 함수 네이밍을 일부 변경했습니다.

+현재 로그인, 회원가입에서 이슈가 발생했고 확인 중에 있습니다. 수정시에 커밋해서 PR올리겠습니다. (현재 드래프트로 올림)



## PR Type
_두 개 이상 체크 시, PR을 나누도록 합니다._

- [X] 새 기능 🚀 (변경 전 코드와 호환 가능)
- [ ] 큰 변경사항 🎇 (변경 전 코드와 호환 불가)
- [X] 코드스타일 수정 👗 (포매터/린터 적용, 네이밍 변경)
- [ ] 리펙터링 ⚙️ (기능수정 금지)
- [ ] 문서내용 변경 📄 (README, Docstring, API문서, 주석 등)
- [ ] 그외 기타 🎸 : ( - )
