### PR TITLE
매치 생성 API 복구

### DIFF
--- a/app/src/main/java/kr/yapp/teamplay/data/match/MatchApi.kt
+++ b/app/src/main/java/kr/yapp/teamplay/data/match/MatchApi.kt
@@ -1,9 +1,8 @@
 package kr.yapp.teamplay.data.match
 
+import io.reactivex.Completable
 import io.reactivex.Single
-import retrofit2.http.GET
-import retrofit2.http.Path
-import retrofit2.http.Query
+import retrofit2.http.*
 
 interface MatchApi {
 
@@ -29,5 +28,11 @@ interface MatchApi {
     fun getDetailedMatchIndividualResult(
         @Path("matchId") matchId: Int
     ): Single<List<MatchIndividualResultResponse>>
+
+    @POST("/v1/matches/{matchId}/matchRequest")
+    fun requestMatch(
+        @Body createMatchRequest: CreateMatchRequest,
+        @Path("matchId") matchId: Int
+    ): Completable
 
 }

--- a/app/src/main/java/kr/yapp/teamplay/data/match/MatchRepositoryImpl.kt
+++ b/app/src/main/java/kr/yapp/teamplay/data/match/MatchRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package kr.yapp.teamplay.data.match
 
+import io.reactivex.Completable
 import io.reactivex.Single
 import kr.yapp.teamplay.data.RetrofitManager
 import kr.yapp.teamplay.domain.entity.matchresult.DetailedMatchResult
@@ -29,5 +30,9 @@ class MatchRepositoryImpl(
             .map { list ->
                 list.map { it.toEntity() }
             }
+
+    override fun requestMatch(createMatchRequest: CreateMatchRequest, matchId: Int): Completable {
+        return matchApi.requestMatch(createMatchRequest, matchId)
+    }
 
 }

--- a/app/src/main/java/kr/yapp/teamplay/domain/repository/MatchRepository.kt
+++ b/app/src/main/java/kr/yapp/teamplay/domain/repository/MatchRepository.kt
@@ -1,6 +1,8 @@
 package kr.yapp.teamplay.domain.repository
 
+import io.reactivex.Completable
 import io.reactivex.Single
+import kr.yapp.teamplay.data.match.CreateMatchRequest
 import kr.yapp.teamplay.data.match.MatchListResponse
 import kr.yapp.teamplay.domain.entity.matchresult.DetailedMatchResult
 import kr.yapp.teamplay.domain.entity.matchresult.MatchIndividualScore
@@ -18,5 +20,7 @@ interface MatchRepository {
     fun getDetailedMatchResult(matchId: Int): Single<DetailedMatchResult>
 
     fun getDetailedMatchIndividualResult(matchId: Int): Single<List<MatchIndividualScore>>
+
+    fun requestMatch(createMatchRequest: CreateMatchRequest, matchId: Int): Completable
 
 }

--- a/app/src/main/java/kr/yapp/teamplay/domain/usecase/PostMatchRequest.kt
+++ b/app/src/main/java/kr/yapp/teamplay/domain/usecase/PostMatchRequest.kt
@@ -1,5 +1,6 @@
 package kr.yapp.teamplay.domain.usecase
 
+import io.reactivex.Completable
 import io.reactivex.Single
 import kr.yapp.teamplay.data.match.CreateMatchRequest
 import kr.yapp.teamplay.data.match.MatchRepositoryImpl
@@ -8,6 +9,6 @@ import kr.yapp.teamplay.domain.repository.MatchRepository
 class PostMatchRequest(
     private val repository : MatchRepository = MatchRepositoryImpl()
 ) {
-    fun requestMatch(createMatchRequest: CreateMatchRequest, matchId: Long) : Single<Any>
+    fun requestMatch(createMatchRequest: CreateMatchRequest, matchId: Int): Completable
             = repository.requestMatch(createMatchRequest, matchId)
 }

--- a/app/src/main/java/kr/yapp/teamplay/presentation/match_detail/MatchDetailViewModel.kt
+++ b/app/src/main/java/kr/yapp/teamplay/presentation/match_detail/MatchDetailViewModel.kt
@@ -12,13 +12,14 @@ import kr.yapp.teamplay.data.teammain.TeamRepositoryImpl
 import kr.yapp.teamplay.domain.entity.matchlist.MatchInfo
 import kr.yapp.teamplay.domain.usecase.PostMatchRequest
 import kr.yapp.teamplay.domain.usecase.TeamMainUseCase
+import kr.yapp.teamplay.presentation.BaseViewModel
 import kr.yapp.teamplay.presentation.util.SingleLiveEvent
 import kr.yapp.teamplay.util.PreferenceManager
 
 class MatchDetailViewModel(
     private val matchRequestUseCase : PostMatchRequest =
         PostMatchRequest(MatchRepositoryImpl())
-) : ViewModel() {
+) : BaseViewModel() {
     val matchInfo : MutableLiveData<MatchInfo> = MutableLiveData()
     val matchRequestSuccess : SingleLiveEvent<Void> = SingleLiveEvent()
     val matchRequestFail : SingleLiveEvent<Void> = SingleLiveEvent()
@@ -29,11 +30,10 @@ class MatchDetailViewModel(
             PreferenceManager.getUserId(TeamPlayApplication.appContext).toLong(), contact
         )
 
-        matchRequestUseCase.requestMatch(createMatchRequest, matchInfo.value!!.id)
+        matchRequestUseCase.requestMatch(createMatchRequest, matchInfo.value!!.id.toInt())
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({
-                Log.d("Request: " , it.hashCode().toString())
                 matchRequestSuccess.call()
             }, {
                 Log.d("Request: " , it.message)
@@ -50,5 +50,6 @@ class MatchDetailViewModel(
                     matchRequestFail.call()
                 }
             })
+            .addDisposable()
     }
 }


### PR DESCRIPTION
# PATCH PR

## 설명
https://github.com/YAPP-16th/Team_Android_2_Client/pull/61 에서 실수로 제거된
`requestMatch` 관련 API 및 함수들을 복구하는 PR 입니다.

## 작업사항
- [x] MatchApi, MatchRepository,MatchRepositoryImpl 에서 requestMatch API 복구 
- [x] 컴파일 및 정상 동작 확인

## PR 타입
- [ ] 새 기능
- [ ] 큰 변경사항
- [ ] 코드스타일 수정
- [ ] 리펙터링
- [ ] 문서내용 변경
- [x] 그외 기타

